### PR TITLE
Windows spawn fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,11 +15,11 @@ if (!fs.existsSync('gulpfile.js')) {
   // Look for gulpfile with another extension
   // and add corresponding --require option to process.argv
   for (var ext in options) {
-  if (fs.existsSync('gulpfile.'+ext)) {
-    process.argv.push('--require');
-    process.argv.push(options[ext]);
-    break;
-  }
+    if (fs.existsSync('gulpfile.'+ext)) {
+      process.argv.push('--require');
+      process.argv.push(options[ext]);
+      break;
+    }
   }
 }
 
@@ -27,7 +27,7 @@ if (!fs.existsSync('gulpfile.js')) {
 
 var callSpawn = function(useCmd){
   return spawn('gulp' + (useCmd ? '.cmd' : ''), process.argv, {
-  stdio: 'inherit'
+    stdio: 'inherit'
   });
 };
 
@@ -36,7 +36,7 @@ callSpawn(false).on('error', function(error){
 
   // if gulp isn't found on Windows, try gulp.cmd
   if(error.code === 'ENOENT' && (platform === 'win32' || platform === 'win64')){
-  callSpawn(true);
+    callSpawn(true);
   }
   else {
     throw error;


### PR DESCRIPTION
Since `cult` seemed to have worked in the past without this, I decided to try spawning `gulp.cmd` only after failing to spawn `gulp` (instead of always spawning `gulp.cmd` for Windows users).

---

If you want me to squash these commits into one I can. 
