### PR TITLE
Prevent killing cult process before gulp on SIGINT

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,15 @@ if (gulpfile) {
   })
 
   run()
+
+  process.on('SIGINT', function() {
+    // Prevent killing the main process before child
+    if (!child) process.exit()
+
+    child.on('exit', function() {
+      process.exit()
+    })
+  })
 } else {
   return log('Can\'t find gulpfile')
 }


### PR DESCRIPTION
Hi!
Cult must wait until gulp process exits before exiting itself on SIGINT.
For example, I wanted to make some cleanup after the watch task, but cult exits immediatelly after Ctrl+C. 
