### PR TITLE
Use process.platform variable instead of os.platform which is a function now.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-var os = require('os')
 var fs = require('fs')
 var respawn = require('respawn')
 var chalk = require('chalk')
@@ -47,7 +46,7 @@ monitor.maxRestarts = 0
 // If on windows and gulp fails, try to replace it with gulp.cmd
 monitor.on('warn', function(err) {
   if (err.code === 'ENOENT') {
-    if (os.platform === 'win32' || os.platform === 'win64') {
+    if (process.platform === 'win32') {
       monitor = respawn(['gulp.cmd'].concat(process.argv), options)
       monitor.maxRestarts = 0
       monitor.on('warn', function(err) {


### PR DESCRIPTION
I tried to use cult on windows but it didn't work. It said:

    [cult] Error, can't find gulp command

I poked around a bit and noticed that os.plaftorm is a function not a variable. I noticed that there is process.plaform variable that has value win32 for all windows systems (my 64 bit windows also) so I used it instead. Now cult works for me.