### PR TITLE
Case insensitive gulpfile search

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var pkg = require('./package.json')
 function findGulpfile() {
   var filenames = fs.readdirSync(process.cwd())
   for (var i in filenames) {
-    if (filenames[i].indexOf('gulpfile.') !== -1) return filenames[i]
+    if (filenames[i].toLowerCase().indexOf('gulpfile.') !== -1) return filenames[i]
   }
 }
 


### PR DESCRIPTION
Even though capitalized gulpfiles are not standard as Gruntfiles, I have seen many examples and tutorials using them that way.

This solves the problem of not finding the gulpfile when it starts with a capital G.
